### PR TITLE
Aprimorando função para iniciar teclado

### DIFF
--- a/G1-S9-A2.c
+++ b/G1-S9-A2.c
@@ -29,9 +29,8 @@ uint mascara_coluna[4];
 
 // Função para inicializar o teclado
 void inicializar_teclado(uint colunas[4], uint linhas[4], char valores[16]) {
-    for (int i = 0; i < 16; i++) {
-        _valores_matriz[i] = valores[i];
-    }
+    
+    memcpy(_valores_matriz, valores, sizeof(char) * 16);
 
     for (int i = 0; i < 4; i++) {
         _colunas[i] = colunas[i];


### PR DESCRIPTION
Substitui o "for" inicial na função inicializar_teclado para que pudesse usar uma função built-in do C chamada memcpy() que é mais eficiente em termos de uso de memoria cache.